### PR TITLE
Use nginx 1.4.5 (stable) with correct modules

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ set -e
 
 # ------------------------------------------------------------------------------------------------
 
-compile_nginx_download=https://dl.dropboxusercontent.com/u/5321751/download/nginx-buildpack/nginx-1.5.10.tar.gz
+compile_nginx_download=https://dl.dropboxusercontent.com/u/5321751/download/nginx-buildpack/nginx-1.4.5.tar.gz
 
 # ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
fixed issue #11

This nginx package was build with the following build script: support/heroku-buildpack
